### PR TITLE
Exposing grain identity and grain runtime on LogViewGrain and QueuedGrain

### DIFF
--- a/src/Orleans/LogViews/ILogViewGrain.cs
+++ b/src/Orleans/LogViews/ILogViewGrain.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Orleans.Concurrency;
+using Orleans.Core;
 using Orleans.Runtime;
 
 namespace Orleans.LogViews
@@ -27,5 +28,18 @@ namespace Orleans.LogViews
     /// <typeparam name="TView">The type of the view</typeparam>
     public class LogViewGrainBase<TView> : Grain
     {
+        public LogViewGrainBase()
+        { }
+
+        /// <summary>
+        /// Grain implementers do NOT have to expose this constructor but can choose to do so.
+        /// This constructor is particularly useful for unit testing where test code can create a Grain and replace
+        /// the IGrainIdentity and IGrainRuntime with test doubles (mocks/stubs).
+        /// </summary>
+        /// <param name="identity"></param>
+        /// <param name="runtime"></param>
+        public LogViewGrainBase(IGrainIdentity identity, IGrainRuntime runtime) : base(identity, runtime)
+        { }
     }
+
 }

--- a/src/Orleans/LogViews/LogViewGrain.cs
+++ b/src/Orleans/LogViews/LogViewGrain.cs
@@ -3,7 +3,9 @@ using Orleans.Concurrency;
 using Orleans.MultiCluster;
 using System;
 using System.Collections.Generic;
+using Orleans.Core;
 using Orleans.LogViews;
+using Orleans.Runtime;
 
 namespace Orleans
 {
@@ -22,6 +24,16 @@ namespace Orleans
         where TLogEntry : class
     {
         protected LogViewGrain()
+        { }
+
+        /// <summary>
+        /// Grain implementers do NOT have to expose this constructor but can choose to do so.
+        /// This constructor is particularly useful for unit testing where test code can create a Grain and replace
+        /// the IGrainIdentity and IGrainRuntime with test doubles (mocks/stubs).
+        /// </summary>
+        /// <param name="identity"></param>
+        /// <param name="runtime"></param>
+        protected LogViewGrain(IGrainIdentity identity, IGrainRuntime runtime) : base(identity, runtime)
         { }
 
         /// the object encapsulating the log view provider functionality and local state

--- a/src/Orleans/QueuedGrains/QueuedGrain.cs
+++ b/src/Orleans/QueuedGrains/QueuedGrain.cs
@@ -4,6 +4,7 @@ using Orleans.Runtime;
 using Orleans.MultiCluster;
 using System;
 using System.Collections.Generic;
+using Orleans.Core;
 using Orleans.LogViews;
 
 namespace Orleans.QueuedGrains
@@ -23,6 +24,16 @@ namespace Orleans.QueuedGrains
         where TDelta : class
     {
         protected QueuedGrain()
+        { }
+
+        /// <summary>
+        /// Grain implementers do NOT have to expose this constructor but can choose to do so.
+        /// This constructor is particularly useful for unit testing where test code can create a Grain and replace
+        /// the IGrainIdentity and IGrainRuntime with test doubles (mocks/stubs).
+        /// </summary>
+        /// <param name="identity"></param>
+        /// <param name="runtime"></param>
+        protected QueuedGrain(IGrainIdentity identity, IGrainRuntime runtime) : base(identity, runtime)
         { }
 
         // the object encapsulating the log view provider functionality and local state


### PR DESCRIPTION
Exposing the grain identity and grain runtime in order to be able to inject for unit testing purposes
