### PR TITLE
Refactor GSI response tracker

### DIFF
--- a/src/OrleansRuntime/GrainDirectory/MultiClusterRegistration/GlobalSingleInstanceActivationMaintainer.cs
+++ b/src/OrleansRuntime/GrainDirectory/MultiClusterRegistration/GlobalSingleInstanceActivationMaintainer.cs
@@ -2,12 +2,12 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Orleans.GrainDirectory;
 using Orleans.SystemTargetInterfaces;
 using Orleans.Runtime.Configuration;
 using Orleans.Runtime.Scheduler;
+using OutcomeState = Orleans.Runtime.GrainDirectory.GlobalSingleInstanceResponseOutcome.OutcomeState;
 
 namespace Orleans.Runtime.GrainDirectory
 {
@@ -244,27 +244,22 @@ namespace Orleans.Runtime.GrainDirectory
                 var address = addresses[i];
 
                 // array that holds the responses
-                var responses = new Task<RemoteClusterActivationResponse>[remoteClusters.Count];
+                var responses = new RemoteClusterActivationResponse[remoteClusters.Count];
 
                 for (int j = 0; j < batchResponses.Count; j++)
-                    responses[j] = Task.FromResult(batchResponses[j][i]);
+                    responses[j] = batchResponses[j][i];
 
                 // response processor
-                var tracker = new GlobalSingleInstanceResponseTracker(responses, address.Grain, logger);
-
-                // since the tracker has all responses already, it is in completed state
-                if (!tracker.Task.IsCompleted)
-                    ProtocolError(address, "assertion error: tracker did not complete");
-
-                var outcome = tracker.Task.Result;
+                var outcomeDetails = GlobalSingleInstanceResponseTracker.GetOutcome(responses, address.Grain, logger);
+                var outcome = outcomeDetails.State;
 
                 if (logger.IsVerbose2)
                     logger.Verbose2("GSIP:M {0} Result={1}", address.Grain.ToString(), outcome.ToString());
 
                 switch (outcome)
                 {
-                    case GlobalSingleInstanceResponseTracker.Outcome.RemoteOwner:
-                    case GlobalSingleInstanceResponseTracker.Outcome.RemoteOwnerLikely:
+                    case OutcomeState.RemoteOwner:
+                    case OutcomeState.RemoteOwnerLikely:
                     {
                         // record activations that lost and need to be deactivated
                         List<ActivationAddress> losers;
@@ -272,10 +267,10 @@ namespace Orleans.Runtime.GrainDirectory
                             loser_activations_per_silo[address.Silo] = losers = new List<ActivationAddress>();
                         losers.Add(address);
 
-                        router.DirectoryPartition.CacheOrUpdateRemoteClusterRegistration(address.Grain, address.Activation, tracker.RemoteOwner.Address);
+                        router.DirectoryPartition.CacheOrUpdateRemoteClusterRegistration(address.Grain, address.Activation, outcomeDetails.RemoteOwnerAddress.Address);
                         continue;
                     }
-                    case GlobalSingleInstanceResponseTracker.Outcome.Succeed:
+                    case OutcomeState.Succeed:
                     {
                         var ok = (router.DirectoryPartition.UpdateClusterRegistrationStatus(address.Grain, address.Activation, GrainDirectoryEntryStatus.Owned, GrainDirectoryEntryStatus.RequestedOwnership));
                         if (ok)
@@ -283,7 +278,7 @@ namespace Orleans.Runtime.GrainDirectory
                         else
                             break;
                     }
-                    case GlobalSingleInstanceResponseTracker.Outcome.Inconclusive:
+                    case OutcomeState.Inconclusive:
                     {
                         break;
                     }

--- a/src/OrleansRuntime/GrainDirectory/MultiClusterRegistration/GlobalSingleInstanceActivationMaintainer.cs
+++ b/src/OrleansRuntime/GrainDirectory/MultiClusterRegistration/GlobalSingleInstanceActivationMaintainer.cs
@@ -244,10 +244,10 @@ namespace Orleans.Runtime.GrainDirectory
                 var address = addresses[i];
 
                 // array that holds the responses
-                var responses = new RemoteClusterActivationResponse[remoteClusters.Count];
+                var responses = new Task<RemoteClusterActivationResponse>[remoteClusters.Count];
 
                 for (int j = 0; j < batchResponses.Count; j++)
-                    responses[j] = batchResponses[j][i];
+                    responses[j] = Task.FromResult(batchResponses[j][i]);
 
                 // response processor
                 var tracker = new GlobalSingleInstanceResponseTracker(responses, address.Grain, logger);

--- a/src/OrleansRuntime/GrainDirectory/MultiClusterRegistration/GlobalSingleInstanceActivationMaintainer.cs
+++ b/src/OrleansRuntime/GrainDirectory/MultiClusterRegistration/GlobalSingleInstanceActivationMaintainer.cs
@@ -254,7 +254,7 @@ namespace Orleans.Runtime.GrainDirectory
                 var outcome = outcomeDetails.State;
 
                 if (logger.IsVerbose2)
-                    logger.Verbose2("GSIP:M {0} Result={1}", address.Grain.ToString(), outcome.ToString());
+                    logger.Verbose2("GSIP:M {0} Result={1}", address.Grain, outcomeDetails);
 
                 switch (outcome)
                 {

--- a/src/OrleansRuntime/GrainDirectory/MultiClusterRegistration/GlobalSingleInstanceRegistrar.cs
+++ b/src/OrleansRuntime/GrainDirectory/MultiClusterRegistration/GlobalSingleInstanceRegistrar.cs
@@ -98,7 +98,7 @@ namespace Orleans.Runtime.GrainDirectory
                 var outcome = await SendRequestRound(address, remoteClusters);
 
                 if (logger.IsVerbose)
-                    logger.Verbose("GSIP:End {0} Round={1} Outcome={2}", address.Grain.ToString(), numRetries - retries, outcome.State);
+                    logger.Verbose("GSIP:End {0} Round={1} Outcome={2}", address.Grain.ToString(), numRetries - retries, outcome);
 
                 switch (outcome.State)
                 {

--- a/src/OrleansRuntime/GrainDirectory/MultiClusterRegistration/GlobalSingleInstanceResponseTracker.cs
+++ b/src/OrleansRuntime/GrainDirectory/MultiClusterRegistration/GlobalSingleInstanceResponseTracker.cs
@@ -29,6 +29,11 @@ namespace Orleans.Runtime.GrainDirectory
             this.RemoteOwnerAddress = remoteOwnerAddress;
             this.RemoteOwnerCluster = remoteOwnerCluster;
         }
+
+        public override string ToString()
+        {
+            return $"[{this.State} {this.RemoteOwnerAddress.Address}]";
+        }
     }
 
     /// <summary>

--- a/src/OrleansRuntime/GrainDirectory/MultiClusterRegistration/GlobalSingleInstanceResponseTracker.cs
+++ b/src/OrleansRuntime/GrainDirectory/MultiClusterRegistration/GlobalSingleInstanceResponseTracker.cs
@@ -1,120 +1,152 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Orleans.GrainDirectory;
 using Orleans.SystemTargetInterfaces;
+using OutcomeState = Orleans.Runtime.GrainDirectory.GlobalSingleInstanceResponseOutcome.OutcomeState;
 
 namespace Orleans.Runtime.GrainDirectory 
 {
-    /// <summary>
-    /// A class that encapsulates response processing logic.
-    /// It is a promise that fires once it has enough responses to make a determination.
-    /// </summary>
-    internal class GlobalSingleInstanceResponseTracker
+    internal struct GlobalSingleInstanceResponseOutcome
     {
-        public enum Outcome {
+        public enum OutcomeState
+        {
             Succeed,
             RemoteOwner,
             RemoteOwnerLikely,
             Inconclusive
         }
 
-        private readonly TaskCompletionSource<Outcome> tcs = new TaskCompletionSource<Outcome>();
+        public static readonly GlobalSingleInstanceResponseOutcome Succeed = new GlobalSingleInstanceResponseOutcome(OutcomeState.Succeed, default(AddressAndTag), null);
+
+        public readonly OutcomeState State;
+        public readonly AddressAndTag RemoteOwnerAddress;
+        public readonly string RemoteOwnerCluster;
+        public GlobalSingleInstanceResponseOutcome(OutcomeState state, AddressAndTag remoteOwnerAddress, string remoteOwnerCluster)
+        {
+            this.State = state;
+            this.RemoteOwnerAddress = remoteOwnerAddress;
+            this.RemoteOwnerCluster = remoteOwnerCluster;
+        }
+    }
+
+    /// <summary>
+    /// A class that encapsulates response processing logic.
+    /// It is a promise that fires once it has enough responses to make a determination.
+    /// </summary>
+    internal class GlobalSingleInstanceResponseTracker
+    {
+        private readonly TaskCompletionSource<GlobalSingleInstanceResponseOutcome> tcs = new TaskCompletionSource<GlobalSingleInstanceResponseOutcome>();
         private readonly GrainId grain;
-        private readonly Task<RemoteClusterActivationResponse>[] responses;
+        private readonly Task<RemoteClusterActivationResponse>[] responsePromises;
         private Logger logger;
 
-        public AddressAndTag RemoteOwner;
-        public string RemoteOwnerCluster;
-
-        public GlobalSingleInstanceResponseTracker(Task<RemoteClusterActivationResponse>[] responses, GrainId grain, Logger logger)
+        private GlobalSingleInstanceResponseTracker(Task<RemoteClusterActivationResponse>[] responsePromises, GrainId grain, Logger logger)
         {
-            this.responses = responses;
-            Debug.Assert(this.responses.All(t => t != null));
+            this.responsePromises = responsePromises;
             this.grain = grain;
             this.logger = logger;
 
             CheckIfDone();
         }
 
+        public static GlobalSingleInstanceResponseOutcome GetOutcome(RemoteClusterActivationResponse[] responses, GrainId grainId, Logger logger)
+        {
+            if (responses.Any(t => t == null)) throw new ArgumentException("All responses should have a value", nameof(responses));
+            return GetOutcome(responses, grainId, logger, hasPendingResponses: false).Value;
+        }
+
+        public static Task<GlobalSingleInstanceResponseOutcome> GetOutcomeAsync(Task<RemoteClusterActivationResponse>[] responsePromises, GrainId grain, Logger logger)
+        {
+            if (responsePromises.Any(t => t == null)) throw new ArgumentException("All response promises should have been initiated", nameof(responsePromises));
+            var details = new GlobalSingleInstanceResponseTracker(responsePromises, grain, logger);
+            return details.Task;
+        }
+
         /// <summary>
         /// Returns the outcome of the response aggregation
         /// </summary>
-        public Task<Outcome> Task => this.tcs.Task;
-
-        // for tracing, display outcome
-        public override string ToString()
-        {
-            if (!this.Task.IsCompleted)
-                return "pending";
-            else if (Task.IsFaulted)
-                return "faulted";
-            else
-            {
-                return
-                    $"[{Task.Result} {RemoteOwner.Address}]";
-            }
-        }
+        private Task<GlobalSingleInstanceResponseOutcome> Task => this.tcs.Task;
 
         /// <summary>
         /// Check responses; signal completion if we have received enough responses to determine outcome.
         /// </summary>
         private void CheckIfDone()
         {
-            if (!Task.IsCompleted)
+            if (!tcs.Task.IsCompleted)
             {
                 // store incomplete promises at this time (as they might be completed by the time the method finishes
-                var incompletePromises = responses.Where(t => !t.IsCompleted).ToArray();
-                if (incompletePromises.Length == 0 && responses.All(res => res.IsCompleted && res.Result.ResponseStatus == ActivationResponseStatus.Pass))
+                var incompletePromises = new List<Task<RemoteClusterActivationResponse>>();
+                var completedPromises = new List<RemoteClusterActivationResponse>();
+                foreach (var promise in this.responsePromises)
                 {
-                   // All passed, or no other clusters exist
-                   tcs.TrySetResult(Outcome.Succeed);
-                   return;
-                }
-
-                var ownerResponses = responses
-                    .Where(t => t.IsCompleted)
-                    .Select(t => t.Result)
-                    .Where(res => res.ResponseStatus == ActivationResponseStatus.Failed && res.Owned == true).ToList();
-
-                if (ownerResponses.Count > 0)
-                {
-                    if (ownerResponses.Count > 1)
-                        logger.Warn((int)ErrorCode.GlobalSingleInstance_MultipleOwners, "GSIP:Req {0} Unexpected error occured. Multiple Owner Replies.", grain);
-
-                    RemoteOwner = ownerResponses[0].ExistingActivationAddress;
-                    RemoteOwnerCluster = ownerResponses[0].ClusterId;
-                    tcs.TrySetResult(Outcome.RemoteOwner);
-                    return;
-                }
-
-                // are all responses here or have failed?
-                if (incompletePromises.Length == 0)
-                {
-                    // determine best candidate
-                    var candidates = responses
-                        .Select(t => t.Result)
-                        .Where(res => res.ResponseStatus == ActivationResponseStatus.Failed && res.ExistingActivationAddress.Address != null)
-                        .ToList();
-
-                    foreach (var res in candidates)
+                    if (promise.IsCompleted)
                     {
-                        if (RemoteOwner.Address == null ||
-                            MultiClusterUtils.ActivationPrecedenceFunc(grain,
-                                res.ClusterId, RemoteOwnerCluster))
-                        {
-                            RemoteOwner = res.ExistingActivationAddress;
-                            RemoteOwnerCluster = res.ClusterId;
-                        }
+                        completedPromises.Add(promise.Result);
                     }
+                    else
+                    {
+                        incompletePromises.Add(promise);
+                    }
+                }
+                var outcome = GetOutcome(completedPromises, this.grain, this.logger, incompletePromises.Count > 0);
+                if (outcome.HasValue)
+                {
+                    tcs.TrySetResult(outcome.Value);
+                }
+                else
+                {
+                    // When any of the promises that where incomplete finishes, re-run the check
+                    System.Threading.Tasks.Task.WhenAny(incompletePromises).ContinueWith(t => CheckIfDone());
+                }
+            }
+        }
 
-                    tcs.TrySetResult(RemoteOwner.Address != null ? Outcome.RemoteOwnerLikely : Outcome.Inconclusive);
-                    return;
+        private static GlobalSingleInstanceResponseOutcome? GetOutcome(ICollection<RemoteClusterActivationResponse> responses, GrainId grainId, Logger logger, bool hasPendingResponses)
+        {
+            if (!hasPendingResponses && responses.All(res => res.ResponseStatus == ActivationResponseStatus.Pass))
+            {
+                // All passed, or no other clusters exist
+                return GlobalSingleInstanceResponseOutcome.Succeed;
+            }
+
+            var ownerResponses = responses
+                .Where(res => res.ResponseStatus == ActivationResponseStatus.Failed && res.Owned == true).ToList();
+
+            if (ownerResponses.Count > 0)
+            {
+                if (ownerResponses.Count > 1)
+                    logger.Warn((int)ErrorCode.GlobalSingleInstance_MultipleOwners, "GSIP:Req {0} Unexpected error occured. Multiple Owner Replies.", grainId);
+
+                return new GlobalSingleInstanceResponseOutcome(OutcomeState.RemoteOwner, ownerResponses[0].ExistingActivationAddress, ownerResponses[0].ClusterId);
+            }
+
+            // are all responses here or have failed?
+            if (!hasPendingResponses)
+            {
+                // determine best candidate
+                var candidates = responses
+                    .Where(res => res.ResponseStatus == ActivationResponseStatus.Failed && res.ExistingActivationAddress.Address != null)
+                    .ToList();
+
+                AddressAndTag remoteOwner = new AddressAndTag();
+                string remoteOwnerCluster = null;
+                foreach (var res in candidates)
+                {
+                    if (remoteOwner.Address == null ||
+                        MultiClusterUtils.ActivationPrecedenceFunc(grainId, res.ClusterId, remoteOwnerCluster))
+                    {
+                        remoteOwner = res.ExistingActivationAddress;
+                        remoteOwnerCluster = res.ClusterId;
+                    }
                 }
 
-                // When any of the promises that where incomplete finishes, re-run the check
-                System.Threading.Tasks.Task.WhenAny(incompletePromises).ContinueWith(t => CheckIfDone());
+                var outcome = remoteOwner.Address != null ? OutcomeState.RemoteOwnerLikely : OutcomeState.Inconclusive;
+                return new GlobalSingleInstanceResponseOutcome(outcome, remoteOwner, remoteOwnerCluster);
             }
+
+            return null;
         }
     }
 }


### PR DESCRIPTION
Simplify GlobalSingleInstanceReponseTracker abstraction.
All the response tracking logic was encapsulated into `GetOutcome` and `GetOutcomeAsync`, with a much clearer responsibility defined by the interface.
This greatly simplifies caller code to avoid using a custom `TaskCompletionSource` and remembering to call into `CheckIfDone()` after mutating shared state (the array that was passed into its constructor), where the responsibilities where not clear. Also avoids using tasks that in theory should be completed (but not enforced by the previous abstraction) when the method returns, when passing the complete batch of responses (instead of an array of responses that would be filled in as responses come back).
