### PR TITLE
Start ClientStatisticsManager after clientID is assigned

### DIFF
--- a/src/Orleans/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans/Runtime/OutsideRuntimeClient.cs
@@ -269,10 +269,7 @@ namespace Orleans
             transport.Start();
             LogManager.MyIPEndPoint = transport.MyAddress.Endpoint; // transport.MyAddress is only set after transport is Started.
             CurrentActivationAddress = ActivationAddress.NewActivationAddress(transport.MyAddress, handshakeClientId);
-
             ClientStatistics = new ClientStatisticsManager(config);
-            ClientStatistics.Start(config, statisticsProviderManager, transport, clientId)
-                .WaitWithThrow(initTimeout);
 
             listeningCts = new CancellationTokenSource();
             var ct = listeningCts.Token;
@@ -292,6 +289,9 @@ namespace Orleans
                 }
             );
             grainInterfaceMap = transport.GetTypeCodeMap(grainFactory).Result;
+
+            ClientStatistics.Start(statisticsProviderManager, transport, clientId)
+                .WaitWithThrow(initTimeout);
 
             StreamingInitialize();
         }

--- a/src/Orleans/Statistics/ClientStatisticsManager.cs
+++ b/src/Orleans/Statistics/ClientStatisticsManager.cs
@@ -7,24 +7,26 @@ namespace Orleans.Runtime
 {
     internal class ClientStatisticsManager
     {
+        private readonly ClientConfiguration config;
         private ClientTableStatistics tableStatistics;
         private LogStatistics logStatistics;
         private RuntimeStatisticsGroup runtimeStats;
         private readonly Logger logger ;
 
-        internal ClientStatisticsManager(IStatisticsConfiguration config)
+        internal ClientStatisticsManager(ClientConfiguration config)
         {
+            this.config = config;
             runtimeStats = new RuntimeStatisticsGroup();
             logStatistics = new LogStatistics(config.StatisticsLogWriteInterval, false);
             logger = LogManager.GetLogger(GetType().Name);
-        }
 
-        internal async Task Start(ClientConfiguration config, StatisticsProviderManager statsManager, IMessageCenter transport, GrainId clientId)
-        {
             MessagingStatisticsGroup.Init(false);
             NetworkingStatisticsGroup.Init(false);
             ApplicationRequestsStatisticsGroup.Init(config.ResponseTimeout);
+        }
 
+        internal async Task Start(StatisticsProviderManager statsManager, IMessageCenter transport, GrainId clientId)
+        {
             runtimeStats.Start();
 
             // Configure Metrics
@@ -83,9 +85,7 @@ namespace Orleans.Runtime
 
         internal void Stop()
         {
-            if (runtimeStats != null)
-                runtimeStats.Stop();
-
+            runtimeStats?.Stop();
             runtimeStats = null;
 
             if (logStatistics != null)
@@ -96,9 +96,7 @@ namespace Orleans.Runtime
 
             logStatistics = null;
 
-            if (tableStatistics != null)
-                tableStatistics.Dispose();
-
+            tableStatistics?.Dispose();
             tableStatistics = null;
         }
     }


### PR DESCRIPTION
Otherwise when using Azure membership, clientId is null and throws `NullReferenceException` in `ClientStatisticsManager.Start`
